### PR TITLE
Kubernetes controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ kubectl apply -f pod.yaml
 - Создать ресурсы:
 
 ```bash
-kubectl apply -f namespace.yaml
-kubectl apply -f nginx-cm.yaml
-kubectl apply -f deployment.yaml
+ubuntu@k3s1 ~>kubectl apply -f namespace.yaml
+ubuntu@k3s1 ~>kubectl apply -f nginx-cm.yaml
+ubuntu@k3s1 ~>kubectl apply -f deployment.yaml
 ```
 
 ## Как проверить работоспособность
@@ -67,7 +67,8 @@ kubectl apply -f deployment.yaml
 - Проверить статус деплоймента:
 
 ```bash
-kubectl -n homework get deployment
+ubuntu@k3s1 ~>kubectl -n homework get deployment
+
 NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
 homework-deployment   0/3     3            0           13s
 ```
@@ -75,7 +76,8 @@ homework-deployment   0/3     3            0           13s
 - Проверить статус подов:
 
 ```bash
-kubectl -n homework get po
+ubuntu@k3s1 ~>kubectl -n homework get po
+
 NAME                                  READY   STATUS    RESTARTS   AGE
 homework-deployment-5c9867b9b-njmbv   0/1     Pending   0          20s
 homework-deployment-5c9867b9b-n4kb2   0/1     Pending   0          20s
@@ -85,7 +87,8 @@ homework-deployment-5c9867b9b-x4bmt   0/1     Pending   0          20s
 - Проверить сообщения указывающий на причину статуса `Pending`:
 
 ```bash
-kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+ubuntu@k3s1 ~>kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+
 LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
 2m3s        Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
 ```
@@ -93,7 +96,8 @@ LAST SEEN   TYPE      REASON             OBJECT                                 
 - Узнать имена нод:
 
 ```bash
-kubectl get nodes
+ubuntu@k3s1 ~>kubectl get nodes
+
 NAME   STATUS   ROLES                  AGE   VERSION
 k3s1   Ready    control-plane,master   22d   v1.28.4+k3s2
 ```
@@ -101,14 +105,16 @@ k3s1   Ready    control-plane,master   22d   v1.28.4+k3s2
 - Применить лейбл к ноде:
 
 ```bash
-kubectl label nodes k3s1 homework=true
+ubuntu@k3s1 ~>kubectl label nodes k3s1 homework=true
+
 node/k3s1 labeled
 ```
 
 - Проверить что поды начали автоматически разворачиваться:
 
 ```bash
-kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+ubuntu@k3s1 ~>kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+
 LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
 4m10s       Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
 13s         Normal    Pulling            Pod/homework-deployment-5c9867b9b-njmbv   Pulling image "busybox:latest"
@@ -125,7 +131,8 @@ LAST SEEN   TYPE      REASON             OBJECT                                 
 - Проверить статус деплоймента:
 
 ```bash
-kubectl -n homework get deployment
+ubuntu@k3s1 ~>kubectl -n homework get deployment
+
 NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
 homework-deployment   3/3     3            3           4m30s
 ```
@@ -133,10 +140,16 @@ homework-deployment   3/3     3            3           4m30s
 - Обновить образ для `web` контейнера в деплойменте:
 
 ```bash
-kubectl -n homework set image deployment/homework-deployment web=nginxinc/nginx-unprivileged:1.25.0-al
+ubuntu@k3s1 ~>kubectl -n homework set image deployment/homework-deployment web=nginxinc/nginx-unprivileged:1.25.0-al
 pine3.17
+
 deployment.apps/homework-deployment image updated
-ubuntu@k3s1 ~/o/02> k -n homework rollout status deployment
+```
+
+- Проверить статус обновления деплоймента:
+
+```bash
+ubuntu@k3s1 ~>kubectl -n homework rollout status deployment
 Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
 Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
 Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# ДЗ № 1. kubernetes-intro
+# Репозиторий для выполнения домашних заданий курса "Инфраструктурная платформа на основе Kubernetes-2023-12"
+
+## ДЗ № 1. kubernetes-intro
 
 - [x] Основное ДЗ
 - [ ] Задание со *
@@ -32,3 +34,121 @@ kubectl apply -f pod.yaml
 
 - Проверить ответ от веб сервера:
 `curl <Pod_IP_Address>:8000`
+
+## ДЗ № 2. kubernetes-intro
+
+- [x] Основное ДЗ
+- [x] Задание со *
+
+## В процессе сделано
+
+1. Скопировал из HW1 манифест для namespace: содержит имя namespace в котором будут разворачиваться ресурсы - `namespace.yaml`
+1. Скопировал из HW1 манифест для configmap : содержит nginx.conf с указанием порта и места хранения index.html - `nginx-cm.yaml`
+1. Написал и применил манифест для deployment - `deployment.yaml` :
+
+
+● Будет иметь стратегию обновления RollingUpdate, настроенную так,
+что в процессе обновления может быть недоступен максимум 1 под
+
+- Создается в namespace homework
+- Запускает 3 экземпляра пода, полностью аналогичных подам из HW1
+- Имеет readiness пробу, проверяющую наличие файла /homework/index.html
+- Имеет стратегию обновления подов RollingUpdate, maxUnavailable = 1
+- Добавлен раздел nodeSelector, который гарантирует, что поды будут запущены только на нодах с меткой homework=true
+
+## Как запустить проект
+
+- Создать ресурсы:
+
+```bash
+kubectl apply -f namespace.yaml
+kubectl apply -f nginx-cm.yaml
+kubectl apply -f deployment.yaml
+```
+
+## Как проверить работоспособность
+
+- Проверить статус деплоймента:
+
+```bash
+kubectl -n homework get deployment
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+homework-deployment   0/3     3            0           13s
+```
+
+- Проверить статус подов:
+
+```bash
+kubectl -n homework get po
+NAME                                  READY   STATUS    RESTARTS   AGE
+homework-deployment-5c9867b9b-njmbv   0/1     Pending   0          20s
+homework-deployment-5c9867b9b-n4kb2   0/1     Pending   0          20s
+homework-deployment-5c9867b9b-x4bmt   0/1     Pending   0          20s
+```
+
+- Проверить сообщения указывающий на причину статуса `Pending`:
+
+```bash
+kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
+2m3s        Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
+```
+
+- Узнать имена нод:
+
+```bash
+kubectl get nodes
+NAME   STATUS   ROLES                  AGE   VERSION
+k3s1   Ready    control-plane,master   22d   v1.28.4+k3s2
+```
+
+- Применить лейбл к ноде:
+
+```bash
+kubectl label nodes k3s1 homework=true
+node/k3s1 labeled
+```
+
+- Проверить что поды начали автоматически разворачиваться:
+
+```bash
+kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv
+LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
+4m10s       Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
+13s         Normal    Pulling            Pod/homework-deployment-5c9867b9b-njmbv   Pulling image "busybox:latest"
+12s         Normal    Scheduled          Pod/homework-deployment-5c9867b9b-njmbv   Successfully assigned homework/homework-deployment-5c9867b9b-njmbv to k3s1
+9s          Normal    Pulled             Pod/homework-deployment-5c9867b9b-njmbv   Successfully pulled image "busybox:latest" in 3.878s (3.878s including waiting)
+9s          Normal    Created            Pod/homework-deployment-5c9867b9b-njmbv   Created container init
+9s          Normal    Started            Pod/homework-deployment-5c9867b9b-njmbv   Started container init
+9s          Normal    Pulling            Pod/homework-deployment-5c9867b9b-njmbv   Pulling image "nginxinc/nginx-unprivileged"
+1s          Normal    Pulled             Pod/homework-deployment-5c9867b9b-njmbv   Successfully pulled image "nginxinc/nginx-unprivileged" in 8.026s (8.026s including waiting)
+1s          Normal    Created            Pod/homework-deployment-5c9867b9b-njmbv   Created container web
+0s          Normal    Started            Pod/homework-deployment-5c9867b9b-njmbv   Started container web
+```
+
+- Проверить статус деплоймента:
+
+```bash
+kubectl -n homework get deployment
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+homework-deployment   3/3     3            3           4m30s
+```
+
+- Обновить образ для `web` контейнера в деплойменте:
+
+```bash
+kubectl -n homework set image deployment/homework-deployment web=nginxinc/nginx-unprivileged:1.25.0-al
+pine3.17
+deployment.apps/homework-deployment image updated
+ubuntu@k3s1 ~/o/02> k -n homework rollout status deployment
+Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
+Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "homework-deployment" rollout to finish: 2 of 3 updated replicas are available...
+deployment "homework-deployment" successfully rolled out
+```

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ kubectl apply -f pod.yaml
 1. Скопировал из HW1 манифест для configmap : содержит nginx.conf с указанием порта и места хранения index.html - `nginx-cm.yaml`
 1. Написал и применил манифест для deployment - `deployment.yaml` :
 
-
-● Будет иметь стратегию обновления RollingUpdate, настроенную так,
-что в процессе обновления может быть недоступен максимум 1 под
-
 - Создается в namespace homework
 - Запускает 3 экземпляра пода, полностью аналогичных подам из HW1
 - Имеет readiness пробу, проверяющую наличие файла /homework/index.html

--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: homework-app
+  template:
+    metadata:
+      labels:
+        app: homework-app
+    spec:
+      nodeSelector:
+        homework: "true"
+      containers:
+      - name: web
+        image: nginxinc/nginx-unprivileged
+        readinessProbe:
+          exec:
+            command: ["cat", "/homework/index.html"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        ports:
+        - containerPort: 8000
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "rm -f /homework/index.html"]
+        resources:
+          limits:
+            cpu: "0.5"
+            memory: "512Mi"
+        volumeMounts:
+        - name: web-volume
+          mountPath: /homework
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d
+          readOnly: true
+      initContainers:
+      - name: init
+        image: busybox:latest
+        command: ['sh', '-c', 'mkdir /init; date > /init/index.html']
+        volumeMounts:
+        - name: web-volume
+          mountPath: /init
+      volumes:
+      - name: web-volume
+        emptyDir: {}
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          items:
+            - key: nginx.conf
+              path: nginx.conf
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-controllers/nginx-cm.yaml
+++ b/kubernetes-controllers/nginx-cm.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  nginx.conf: |-
+      server {
+          listen       8000;
+          server_name  localhost;
+          location / {
+            root   /homework;
+            index  index.html index.htm;
+        }
+      }


### PR DESCRIPTION
# Выполнено ДЗ № 2

- [x] Основное ДЗ
- [x] Задание со *

## В процессе сделано:

1. Скопировал из HW1 манифест для namespace: содержит имя namespace в котором будут разворачиваться ресурсы - `namespace.yaml`
1. Скопировал из HW1 манифест для configmap : содержит nginx.conf с указанием порта и места хранения index.html - `nginx-cm.yaml`
1. Написал и применил манифест для deployment - `deployment.yaml` :

- Создается в namespace homework
- Запускает 3 экземпляра пода, полностью аналогичных подам из HW1
- Имеет readiness пробу, проверяющую наличие файла /homework/index.html
- Имеет стратегию обновления подов RollingUpdate, maxUnavailable = 1
- Добавлен раздел nodeSelector, который гарантирует, что поды будут запущены только на нодах с меткой homework=true

## Как запустить проект:

- Создать ресурсы:

```bash
ubuntu@k3s1 ~>kubectl apply -f namespace.yaml
ubuntu@k3s1 ~>kubectl apply -f nginx-cm.yaml
ubuntu@k3s1 ~>kubectl apply -f deployment.yaml
```
## Как проверить работоспособность:

- Проверить статус деплоймента:

```bash
ubuntu@k3s1 ~>kubectl -n homework get deployment

NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
homework-deployment   0/3     3            0           13s
```

- Проверить статус подов:

```bash
ubuntu@k3s1 ~>kubectl -n homework get po

NAME                                  READY   STATUS    RESTARTS   AGE
homework-deployment-5c9867b9b-njmbv   0/1     Pending   0          20s
homework-deployment-5c9867b9b-n4kb2   0/1     Pending   0          20s
homework-deployment-5c9867b9b-x4bmt   0/1     Pending   0          20s
```

- Проверить сообщения указывающий на причину статуса `Pending`:

```bash
ubuntu@k3s1 ~>kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv

LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
2m3s        Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
```

- Узнать имена нод:

```bash
ubuntu@k3s1 ~>kubectl get nodes

NAME   STATUS   ROLES                  AGE   VERSION
k3s1   Ready    control-plane,master   22d   v1.28.4+k3s2
```

- Применить лейбл к ноде:

```bash
ubuntu@k3s1 ~>kubectl label nodes k3s1 homework=true

node/k3s1 labeled
```

- Проверить что поды начали автоматически разворачиваться:

```bash
ubuntu@k3s1 ~>kubectl -n homework events --for pod/homework-deployment-5c9867b9b-njmbv

LAST SEEN   TYPE      REASON             OBJECT                                    MESSAGE
4m10s       Warning   FailedScheduling   Pod/homework-deployment-5c9867b9b-njmbv   0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
13s         Normal    Pulling            Pod/homework-deployment-5c9867b9b-njmbv   Pulling image "busybox:latest"
12s         Normal    Scheduled          Pod/homework-deployment-5c9867b9b-njmbv   Successfully assigned homework/homework-deployment-5c9867b9b-njmbv to k3s1
9s          Normal    Pulled             Pod/homework-deployment-5c9867b9b-njmbv   Successfully pulled image "busybox:latest" in 3.878s (3.878s including waiting)
9s          Normal    Created            Pod/homework-deployment-5c9867b9b-njmbv   Created container init
9s          Normal    Started            Pod/homework-deployment-5c9867b9b-njmbv   Started container init
9s          Normal    Pulling            Pod/homework-deployment-5c9867b9b-njmbv   Pulling image "nginxinc/nginx-unprivileged"
1s          Normal    Pulled             Pod/homework-deployment-5c9867b9b-njmbv   Successfully pulled image "nginxinc/nginx-unprivileged" in 8.026s (8.026s including waiting)
1s          Normal    Created            Pod/homework-deployment-5c9867b9b-njmbv   Created container web
0s          Normal    Started            Pod/homework-deployment-5c9867b9b-njmbv   Started container web
```

- Проверить статус деплоймента:

```bash
ubuntu@k3s1 ~>kubectl -n homework get deployment

NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
homework-deployment   3/3     3            3           4m30s
```

- Обновить образ для `web` контейнера в деплойменте:

```bash
ubuntu@k3s1 ~>kubectl -n homework set image deployment/homework-deployment web=nginxinc/nginx-unprivileged:1.25.0-al
pine3.17

deployment.apps/homework-deployment image updated
```

- Проверить статус обновления деплоймента:

```bash
ubuntu@k3s1 ~>kubectl -n homework rollout status deployment
Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "homework-deployment" rollout to finish: 2 out of 3 new replicas have been updated...
Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "homework-deployment" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "homework-deployment" rollout to finish: 2 of 3 updated replicas are available...
deployment "homework-deployment" successfully rolled out
```

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
