### PR TITLE
homework 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,3 +542,71 @@ ubuntu@k3s1 ~> kubectl -n homework get all
 ```
 
 См. команды из ДЗ #4
+
+## ДЗ № 7. kubernetes-operators
+
+- [x] Задание
+- [x] Задание c *
+- [ ] Задание c **
+
+## В процессе сделано
+
+1. Создал манифест CRD (kind Mysql)
+1. Создал сопутствующие манифесты: ClusterRole, ClusterRoleBinding (сначала широкий набор прав, потом обновлено на миниальный набор прав в соответствии с заданием с *), ServiceAccount
+1. Создал манифест Deployment для ранее созданного оператора
+
+## Как запустить проект
+
+- Применить все манифесты:
+
+```bash
+ubuntu@k3s1 ~> kubectl apply -f .
+clusterrole.rbac.authorization.k8s.io/mysql-operator created
+clusterrolebinding.rbac.authorization.k8s.io/mysql-operator created
+customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
+deployment.apps/mysql-operator created
+mysql.otus.homework/mysql created
+serviceaccount/mysql-operator created
+```
+
+## Как проверить работоспособность
+
+- Убедиться что ресурсы созданы и в рабочем состоянии:
+
+```bash
+ubuntu@k3s1 ~> kubectl get all
+NAME                                  READY   STATUS    RESTARTS   AGE
+pod/mysql-operator-6d79cb54f8-q5nx8   1/1     Running   0          12m
+pod/mysql-5b4846bfd6-v7jcq            1/1     Running   0          12m
+
+NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
+service/kubernetes   ClusterIP   10.43.0.1    <none>        443/TCP    122d
+service/mysql        ClusterIP   None         <none>        3306/TCP   12m
+
+NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/mysql-operator   1/1     1            1           12m
+deployment.apps/mysql            1/1     1            1           12m
+
+NAME                                        DESIRED   CURRENT   READY   AGE
+replicaset.apps/mysql-operator-6d79cb54f8   1         1         1       12m
+replicaset.apps/mysql-5b4846bfd6            1         1         1       12m
+```
+
+- Убедиться что все ресурсы удаляются:
+
+```bash
+ubuntu@k3s1 ~> kubectl delete -f .
+clusterrole.rbac.authorization.k8s.io "mysql-operator" deleted
+clusterrolebinding.rbac.authorization.k8s.io "mysql-operator" deleted
+customresourcedefinition.apiextensions.k8s.io "mysqls.otus.homework" deleted
+deployment.apps "mysql-operator" deleted
+mysql.otus.homework "mysql" deleted
+persistentvolumeclaim "mysql-pvc" deleted
+serviceaccount "mysql-operator" deleted
+
+ubuntu@k3s1 ~> kubectl get all
+No resources found in default namespace.
+
+ubuntu@k3s1 ~> kubectl get mysql.otus.homework/mysql
+error: the server doesn't have a resource type "mysql"
+```

--- a/kubernetes-operators/clusterrole.yaml
+++ b/kubernetes-operators/clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mysql-operator
+rules:
+- apiGroups: ["otus.homework"]
+  resources: ["mysqls"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["services", "persistentvolumes", "persistentvolumeclaims"]
+  verbs: ["create", "patch", "update", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["create", "patch", "update", "delete"]

--- a/kubernetes-operators/clusterrolebinding.yaml
+++ b/kubernetes-operators/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mysql-operator
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mysql-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: mysqls.otus.homework
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: otus.homework
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: mysqls
+    # singular name to be used as an alias on the CLI and for display
+    singular: mysql
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: MySQL
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - mysql

--- a/kubernetes-operators/deployment.yaml
+++ b/kubernetes-operators/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+  labels:
+    app: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql-operator
+  template:
+    metadata:
+      labels:
+        app: mysql-operator
+    spec:
+      containers:
+      - name: mysql-operator
+        image: roflmaoinmysoul/mysql-operator:1.0.0
+      serviceAccountName: mysql-operator

--- a/kubernetes-operators/mysql.yaml
+++ b/kubernetes-operators/mysql.yaml
@@ -1,0 +1,9 @@
+apiVersion: "otus.homework/v1"
+kind: MySQL
+metadata:
+  name: mysql
+spec:
+  image: mysql
+  database: otus
+  password: P@ssw0rd
+  storage_size: 1Gi

--- a/kubernetes-operators/serviceaccount.yaml
+++ b/kubernetes-operators/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator
+  namespace: default


### PR DESCRIPTION
## ДЗ № 7. kubernetes-operators

- [x] Задание
- [x] Задание c *
- [ ] Задание c **

## В процессе сделано

1. Создал манифест CRD (kind Mysql)
1. Создал сопутствующие манифесты: ClusterRole, ClusterRoleBinding (сначала широкий набор прав, потом обновлено на миниальный набор прав в соответствии с заданием с *), ServiceAccount
1. Создал манифест Deployment для ранее созданного оператора

## Как запустить проект

- Применить все манифесты:

```bash
ubuntu@k3s1 ~> kubectl apply -f .
clusterrole.rbac.authorization.k8s.io/mysql-operator created
clusterrolebinding.rbac.authorization.k8s.io/mysql-operator created
customresourcedefinition.apiextensions.k8s.io/mysqls.otus.homework created
deployment.apps/mysql-operator created
mysql.otus.homework/mysql created
serviceaccount/mysql-operator created
```

## Как проверить работоспособность

- Убедиться что ресурсы созданы и в рабочем состоянии:

```bash
ubuntu@k3s1 ~> kubectl get all
NAME                                  READY   STATUS    RESTARTS   AGE
pod/mysql-operator-6d79cb54f8-q5nx8   1/1     Running   0          12m
pod/mysql-5b4846bfd6-v7jcq            1/1     Running   0          12m

NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
service/mysql        ClusterIP   None         <none>        3306/TCP   12m

NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/mysql-operator   1/1     1            1           12m
deployment.apps/mysql            1/1     1            1           12m

NAME                                        DESIRED   CURRENT   READY   AGE
replicaset.apps/mysql-operator-6d79cb54f8   1         1         1       12m
replicaset.apps/mysql-5b4846bfd6            1         1         1       12m
```

- Убедиться что все ресурсы удаляются:

```bash
ubuntu@k3s1 ~> kubectl delete -f .
clusterrole.rbac.authorization.k8s.io "mysql-operator" deleted
clusterrolebinding.rbac.authorization.k8s.io "mysql-operator" deleted
customresourcedefinition.apiextensions.k8s.io "mysqls.otus.homework" deleted
deployment.apps "mysql-operator" deleted
mysql.otus.homework "mysql" deleted
persistentvolumeclaim "mysql-pvc" deleted
serviceaccount "mysql-operator" deleted

ubuntu@k3s1 ~> kubectl get all
No resources found in default namespace.

ubuntu@k3s1 ~> kubectl get mysql.otus.homework/mysql
error: the server doesn't have a resource type "mysql"
```
