### PR TITLE
homework 8

### DIFF
--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-status
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-status
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      name: nginx-status
+      labels:
+        app: nginx-status
+    spec:
+      containers:
+      - name: nginx-status
+        image: batkovyu/otus_nginx:0.1
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+      - name: nginx-prometheus-exporter
+        args:
+          - "--nginx.scrape-uri=http://localhost:8080/metrics"
+        image: nginx/nginx-prometheus-exporter:latest
+        ports:
+          - name: metrics
+            containerPort: 9113
+      nodeSelector:
+        homework: "true"

--- a/kubernetes-monitoring/nginx/Dockerfile
+++ b/kubernetes-monitoring/nginx/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginxinc/nginx-unprivileged
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-monitoring/nginx/nginx.conf
+++ b/kubernetes-monitoring/nginx/nginx.conf
@@ -1,0 +1,49 @@
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        location = /metrics {
+            stub_status;
+        }
+
+        error_page   500 502 503 504  /50x.html;
+        location = /50x.html {
+            root   /usr/share/nginx/html;
+        }
+    }
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-status
+  labels:
+    app: nginx-status
+spec:
+  selector:
+    app: nginx-status
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http
+    - port: 9113
+      targetPort: 9113
+      name: metrics

--- a/kubernetes-monitoring/servicemonitor.yaml
+++ b/kubernetes-monitoring/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-status
+  labels:
+    team: homework
+spec:
+  selector:
+    matchLabels:
+      app: nginx-status
+  endpoints:
+  - path: /metrics
+    port: metrics
+  jobLabel: nginx-status


### PR DESCRIPTION
## ДЗ № 8. kubernetes-monitoring

- [x] Задание


## В процессе сделано

1. Создал образ nginx (на основе nginx-unprivileged) отдающий метрики по /metrics
1. Установил prometheus-operator с помощью helm
1. Создал манифесты Deployment (добавлен второй контейнер с nginx prometheus exporter) и Service
1. Создал манифест ServiceMonitor, описывающий сбор метрик

## Как запустить проект

- Создать и запушить в репозиторий кастомный образ с nginx:
```bash
ubuntu@k3s1 ~> docker build . -t nginx:0.1
ubuntu@k3s1 ~> docker image tag nginx:0.1 batkovyu/otus_nginx:0.1
ubuntu@k3s1 ~> docker push batkovyu/otus_nginx:0.1
```

- Установить prometheus-operator:
```bash
ubuntu@k3s1 ~> export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
ubuntu@k3s1 ~> helm upgrade --install kube-prometheus oci://registry-1.docker.io/bitnamicharts/kube-prometheus -n monitoring --create-namespace
Release "kube-prometheus" does not exist. Installing it now.
Pulled: registry-1.docker.io/bitnamicharts/kube-prometheus:9.0.5
Digest: sha256:634c95f08e34ea3e3492909c9d5c654d5e4dcc8e5cd49a334fe7fbe24b646413
NAME: kube-prometheus
LAST DEPLOYED: Sat May  4 06:39:38 2024
NAMESPACE: monitoring
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
CHART NAME: kube-prometheus
CHART VERSION: 9.0.5
APP VERSION: 0.73.2
...

```

- Применить все манифесты:

```bash
ubuntu@k3s1 ~> kubectl apply -f .
deployment.apps/nginx-status created
service/nginx-status created
servicemonitor.monitoring.coreos.com/nginx-status created
```

## Как проверить работоспособность

- Убедиться что ресурсы созданы и в рабочем состоянии:

```bash
ubuntu@k3s1 ~> kubectl get all
NAME                                READY   STATUS    RESTARTS   AGE
pod/nginx-status-65d4c4dcbb-qzggd   2/2     Running   0          61s

NAME                   TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
service/kubernetes     ClusterIP   10.43.0.1       <none>        443/TCP             110m
service/nginx-status   ClusterIP   10.43.236.237   <none>        8080/TCP,9113/TCP   61s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/nginx-status   1/1     1            1           61s

NAME                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/nginx-status-65d4c4dcbb   1         1         1       61s
```

- Пробросить порт сервиса Prometheus на локальную машину:

```bash
ubuntu@k3s1 ~> kubectl -n monitoring port-forward --address 0.0.0.0 service/kube-prometheus-prometheus 9090:9090
Forwarding from 0.0.0.0:9090 -> 9090
Handling connection for 9090
```

- Зайти адресу http://192.168.1.228:9090 и убедиться, что метрики nginx присутствуют. Пример:

```bash
nginx_connections_accepted{container="nginx-prometheus-exporter", endpoint="metrics", instance="10.42.0.13:9113", job="nginx-status", namespace="default", pod="nginx-status-65d4c4dcbb-qzggd", service="nginx-status"}
103
```