### PR TITLE
homework 12

### DIFF
--- a/kubernetes-csi/PersistentVolumeClaim.yaml
+++ b/kubernetes-csi/PersistentVolumeClaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-s3-pvc
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-s3

--- a/kubernetes-csi/Pod.yaml
+++ b/kubernetes-csi/Pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csi-nginx
+  namespace: default
+spec:
+  containers:
+   - name: csi-nginx
+     image: nginxinc/nginx-unprivileged
+     volumeMounts:
+       - mountPath: /data
+         name: otus-m11
+  volumes:
+   - name: otus-m11
+     persistentVolumeClaim:
+       claimName: csi-s3-pvc
+       readOnly: false

--- a/kubernetes-csi/Secret.yaml
+++ b/kubernetes-csi/Secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-s3-secret
+  namespace: kube-system
+stringData:
+  accessKeyID: removed
+  secretAccessKey: removed
+  endpoint: https://storage.yandexcloud.net

--- a/kubernetes-csi/StorageClass.yaml
+++ b/kubernetes-csi/StorageClass.yaml
@@ -1,0 +1,17 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: csi-s3
+provisioner: ru.yandex.s3.csi
+parameters:
+  mounter: geesefs
+  options: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+  bucket: sb-otus-01
+  csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+  csi.storage.k8s.io/node-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: kube-system

--- a/kubernetes-csi/terraform/.gitignore
+++ b/kubernetes-csi/terraform/.gitignore
@@ -1,0 +1,6 @@
+sa-terraform-authorized-key.json
+terraform.tfstate.backup
+terraform.tfstate
+.terraform.lock.hcl
+.terraform.tfstate.lock.info
+.terraform

--- a/kubernetes-csi/terraform/iam.tf
+++ b/kubernetes-csi/terraform/iam.tf
@@ -1,0 +1,25 @@
+
+#SECTION Service Accounts
+
+resource "yandex_iam_service_account" "sa-s3" {
+  name      = "sa-s3-otus"
+  folder_id = var.folder_id
+}
+
+
+#SECTION Service Account folder bindings
+
+resource "yandex_resourcemanager_folder_iam_binding" "storage-editor" {
+  folder_id = var.folder_id
+  role      = "storage.editor"
+  members = [
+    "serviceAccount:${yandex_iam_service_account.sa-s3.id}"
+  ]
+}
+
+
+#SECTION Service Account static access keys
+
+resource "yandex_iam_service_account_static_access_key" "sa-s3-static-key" {
+  service_account_id = yandex_iam_service_account.sa-s3.id
+}

--- a/kubernetes-csi/terraform/k8s.tf
+++ b/kubernetes-csi/terraform/k8s.tf
@@ -1,0 +1,38 @@
+module "kube" {
+  cluster_version = "1.28"
+  source          = "github.com/terraform-yc-modules/terraform-yc-kubernetes.git"
+  network_id      = yandex_vpc_network.vpc-01.id
+
+  master_locations = [
+    {
+      zone      = "ru-central1-a",
+      subnet_id = yandex_vpc_subnet.snet-01.id
+    }
+  ]
+
+  master_maintenance_windows = [
+    {
+      day        = "monday"
+      start_time = "23:00"
+      duration   = "3h"
+    }
+  ]
+
+  node_groups = {
+
+    "ng-01" = {
+      node_memory = 2
+      node_cores  = 2
+      disk_size   = 30
+      description = "Kubernetes infra group 01"
+      fixed_scale = {
+        size = 1
+      }
+      node_labels = {
+        role        = "infra-01"
+        environment = "infra"
+      }
+
+    }
+  }
+}

--- a/kubernetes-csi/terraform/network.tf
+++ b/kubernetes-csi/terraform/network.tf
@@ -1,0 +1,31 @@
+
+# SECTION VPC
+resource "yandex_vpc_network" "vpc-01" {
+  name = "vpc-01"
+}
+
+# SECTION Subnets
+resource "yandex_vpc_subnet" "snet-01" {
+  name           = "snet-01"
+  zone           = "ru-central1-a"
+  network_id     = yandex_vpc_network.vpc-01.id
+  v4_cidr_blocks = ["10.5.0.0/24"]
+  route_table_id = yandex_vpc_route_table.rt.id
+}
+
+resource "yandex_vpc_gateway" "nat_gateway" {
+  folder_id = var.folder_id
+  name      = "k8s-gateway"
+  shared_egress_gateway {}
+}
+
+resource "yandex_vpc_route_table" "rt" {
+  folder_id  = var.folder_id
+  name       = "test-route-table"
+  network_id = yandex_vpc_network.vpc-01.id
+
+  static_route {
+    destination_prefix = "0.0.0.0/0"
+    gateway_id         = yandex_vpc_gateway.nat_gateway.id
+  }
+}

--- a/kubernetes-csi/terraform/provider.tf
+++ b/kubernetes-csi/terraform/provider.tf
@@ -1,0 +1,6 @@
+provider "yandex" {
+  service_account_key_file = "sa-terraform-authorized-key.json"
+  cloud_id                 = var.cloud_id
+  folder_id                = var.folder_id
+  zone                     = "ru-central1-a"
+}

--- a/kubernetes-csi/terraform/s3.tf
+++ b/kubernetes-csi/terraform/s3.tf
@@ -1,0 +1,6 @@
+resource "yandex_storage_bucket" "sb-otus-01" {
+  bucket     = "sb-otus-01"
+  folder_id  = var.folder_id
+  access_key = yandex_iam_service_account_static_access_key.sa-s3-static-key.access_key
+  secret_key = yandex_iam_service_account_static_access_key.sa-s3-static-key.secret_key
+}

--- a/kubernetes-csi/terraform/terraform.tfvars
+++ b/kubernetes-csi/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+cloud_id  = "b1g71ulsojgm7hdmj6p5"
+folder_id = "b1g0lkreoq9n4uuut9p4"

--- a/kubernetes-csi/terraform/variables.tf
+++ b/kubernetes-csi/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "cloud_id" {
+  description = "Cloud id where to create the sources"
+  type        = string
+}
+
+variable "folder_id" {
+  description = "Folder id where to create the sources"
+  type        = string
+}

--- a/kubernetes-csi/terraform/versions.tf
+++ b/kubernetes-csi/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.7.0"
+  required_providers {
+    yandex = {
+      source  = "yandex-cloud/yandex"
+      version = "0.117.0"
+    }
+  }
+
+}


### PR DESCRIPTION
## ДЗ № 12. kubernetes-vault

- [x] Задание

## В процессе сделано

1. Развернул Managed Kubernetes кластер и S3 бакет в Yandex Cloud с помощью terraform. В кластере один пул нод infra, с количеством узлов в пуле - 1
1. Установил helm чарт для csi-s3
1. Применил манифесты для Secret, StorageClass, PersistentVolumeClaim и Pod

## Как запустить проект

- Иницализировать terraform и применить конфигурацию:

```bash
ubuntu@k3s1 ~> terraform init
ubuntu@k3s1 ~> terraform apply
```

- Инициализировать kubeconfig:

```bash
ubuntu@k3s1 ~> yc managed-kubernetes cluster get-credentials <k8s_cluster_id> --external
```

- Добавить репозиторий с helm-чартамом csi-s3:

```bash
ubuntu@k3s1 ~> helm repo add yandex-s3 https://yandex-cloud.github.io/k8s-csi-s3/charts
"yandex-s3" has been added to your repositories

```

- Установить релиз csi-s3:

```bash
ubuntu@k3s1 ~> helm install csi-s3 yandex-s3/csi-s3
NAME: csi-s3
LAST DEPLOYED: Fri May 10 21:43:06 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

- Применить манифест для Secret:

```bash
ubuntu@k3s1 ~> kubectl apply -f Secret.yaml
secret/csi-s3-secret created
```

- Применить манифест для StorageClass:

```bash
ubuntu@k3s1 ~> kubectl apply -f StorageClass.yaml
storageclass.storage.k8s.io/csi-s3 created
```

- Применить манифест для PersistentVolumeClaim:

```bash
ubuntu@k3s1 ~> kubectl apply -f PersistentVolumeClaim.yaml
persistentvolumeclaim/csi-s3-pvc created
```

- Применить манифест для Pod:

```bash
ubuntu@k3s1 ~> kubectl apply -f Pod.yaml
pod/csi-nginx created
```

## Как проверить работоспособность

- PVC в статусе Bound:

```bash
ubuntu@k3s1 ~> kubectl get pvc csi-s3-pvc
NAME         STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
csi-s3-pvc   Bound    pvc-27b59afb-27c1-47b9-9a82-89e2b1bf8e5e   10Gi       RWX            csi-s3         92s
```

- Volume примонтирован в контейнер:

```bash
ubuntu@k3s1 ~> kubectl exec -ti csi-nginx -- mount | grep fuse
sb-otus-01 on /data type fuse.geesefs (rw,nosuid,nodev,relatime,user_id=65534,group_id=0,default_permissions,allow_other)
```

- Файлы видны в S3 бакете в GUI Yandex Cloud.
